### PR TITLE
Upgrade vitessce

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   'numpy>=1.21.2',
   'zarr>=2.5.0,<3',
   'numcodecs>=0.5.7,<0.16.0',
-  'vitessce[all] >=3.6.4',
+  'vitessce[all] >=3.6.9',
   'scanpy >= 1.11.3',
   'anndata >= 0.11.4'
 ]

--- a/src/easy_vitessce/VitessceSpatialData.py
+++ b/src/easy_vitessce/VitessceSpatialData.py
@@ -30,7 +30,7 @@ class VitessceSpatialData:
         :returns: Self, allows for chaining.
         """
         self.sdata_filepath = spatialdata_filepath
-        self.vc = VitessceConfig(schema_version="1.0.16", name='spatial data')
+        self.vc = VitessceConfig(schema_version="1.0.18", name='spatial data')
         self.kwargs = {"sdata_path": self.sdata_filepath,
                 # The following paths are relative to the root of the SpatialData zarr store on-disk.
                 "table_path":"tables/table",
@@ -88,7 +88,7 @@ class VitessceSpatialData:
         :param str element: location of label data in "labels" folder.
         :returns: Self, allows for chaining.
         """
-        labels_path = {"labels_path":f"labels/{element}"}
+        labels_path = {"obs_segmentations_path":f"labels/{element}"}
         self.kwargs.update(labels_path)
 
         return self


### PR DESCRIPTION
This pull request upgrades the python package listed in pyproject.toml. 
I recently made a minor change to the parameters for the SpatialDataWrapper class (https://github.com/vitessce/vitessce-python/pull/460) which also require setting `schema_version="1.0.18"` when creating the VitessceConfig object, so I have made those changes here as well. The schema version change is also listed at https://vitessce.io/docs/view-config-json/#version